### PR TITLE
Optimize facets speed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'webpacker', '~> 5.0'
 # Data exploration
 gem 'activeadmin'
 gem 'devise', '~> 4.7'
-gem 'forty_facets'
+gem 'forty_facets', github: 'yagudaev/forty_facets', branch: 'optimize-facets-speed'
 gem 'pagy'
 gem 'searchjoy'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/yagudaev/forty_facets.git
+  revision: ee67835831f420e84383407bc85f7ec1884fde29
+  branch: optimize-facets-speed
+  specs:
+    forty_facets (0.1.9.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -94,7 +101,6 @@ GEM
     formtastic (4.0.0)
       actionpack (>= 5.2.0)
     formtastic_i18n (0.6.0)
-    forty_facets (0.1.9.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     google-protobuf (3.15.8)
@@ -284,7 +290,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
   devise (~> 4.7)
-  forty_facets
+  forty_facets!
   jbuilder (~> 2.7)
   listen (~> 3.3)
   newrelic-infinite_tracing

--- a/app/models/title.rb
+++ b/app/models/title.rb
@@ -26,12 +26,12 @@ class Title < ApplicationRecord
   class Faceter < FortyFacets::FacetSearch
     model 'Title'
 
-    facet [:actors, :full_name], name: "actors-full_name"
-    facet :type
-    facet :year
-    facet :color
-    facet :score
-    facet :rating, order: ->(label) { -label }
+    facet [:actors, :full_name], name: "actors-full_name", top: 10
+    facet :type, top: 10, skip_distinct: true, skip_ordering: true
+    facet :year, top: 10, skip_distinct: true, skip_ordering: true
+    facet :color, top: 10, skip_distinct: true, skip_ordering: true
+    facet :score, top: 10, skip_distinct: true, skip_ordering: true
+    facet :rating, order: ->(label) { -label }, skip_distinct: true, skip_ordering: true
   end
 
   class << self


### PR DESCRIPTION
Optimize the facet generation speed by using a fork of the gem and skipping things like distinct and using a limit.

Before
![Screen Shot 2021-04-13 at 5 29 02 PM](https://user-images.githubusercontent.com/1386966/114637282-cb43df00-9c7d-11eb-8e33-61c71023d904.png)

After
![Screen Shot 2021-04-13 at 5 15 27 PM](https://user-images.githubusercontent.com/1386966/114637129-7a33eb00-9c7d-11eb-9a25-b2957a88054e.png)

As you can see the bottleneck now is the database itself. Queries like this take a second to complete:

![Screen Shot 2021-04-13 at 5 31 01 PM](https://user-images.githubusercontent.com/1386966/114637408-1e1d9680-9c7e-11eb-9d71-17ad49d38e27.png)
